### PR TITLE
Fix accessing the file arguments with GHC calling conventions

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -101,7 +101,7 @@ main = do
       ts = setLang (optLanguage opts) (optTargetStyle opts)
       (istream, ostream) =
         case nonOptions of
-          (i:o:_) | optGhc opts -> (T.readFile i, T.writeFile o)
+          (_:i:o:_) | optGhc opts -> (T.readFile i, T.writeFile o)
                   | otherwise -> error "Two arguments required: Input and output file"
           _ -> (optInputFile opts, optOutputFile opts)
 


### PR DESCRIPTION
Fixes #10. Works for me as a literate preprocessor now.

This is super fragile, but I don't want to go replacing the options parsing right now ;)